### PR TITLE
Add late ping support

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ var bot = new irc.Client(config.server, config.botName, {
 var milestones = {
   'acid2': 4
 };
+var pings={};
 
 function searchGithub(params, org, repo, callback) {
   var reqParams = {
@@ -84,6 +85,22 @@ function findIssue(from, to, search) {
     bot.say(to, message);
   });
 }
+
+// Listener for the autopinger
+bot.addListener("join",function(channel,who){
+  who = who.toLowerCase();
+  if (pings[who]) {
+   var to = channel;
+   if (pings[who].length > 5){
+     to = who; // Avoid spam, PM if there are a lot of  pings
+   }
+   for (i in pings[who]) {
+    var tempto = pings[who][i].silent ? who : to; // For messages marked "silent"
+    bot.say(tempto, who + ": " + pings[who][i].from + " said " + pings[who][i].message)
+   }
+   delete pings[who];
+  }
+});
 
 bot.addListener("message", function(from, to, message) {
   if (from == 'ghservo') {
@@ -190,6 +207,19 @@ bot.addListener("message", function(from, to, message) {
       bot.action(to, reply.substring(4));
     } else {
       bot.say(to, reply);
+    }
+    return;
+  }
+  if (message.indexOf('ping ') > -1) {
+    try {
+      var command = message.match(/(ping)(.*)/)[2].trim().match(/([^ ]*) (.*)/);
+      pingee = command[1].toLowerCase();
+      if (!pings[pingee]) {
+        pings[pingee] = [];
+      }
+      pings[pingee].push({"from": from, "message": command[2], "silent": (message.indexOf("silentping") > -1)});
+    } catch(e) {
+      bot.say(to,"Please specify a nick and a message")
     }
     return;
   }


### PR DESCRIPTION
This lets one say `crowbot: ping Manishearth <message>` or `crowbot: silentping Manishearth <message>`, and the bot will ping the user (in the channel or in a PM respectively) when they next join.

If there are more than 5 stored pings for a user, they all are sent via PM.

Currently this doesn't check if the user is already in the room, I'm not sure if this is necessary.
