### PR TITLE
Add command to find unassigned PR's

### DIFF
--- a/server.js
+++ b/server.js
@@ -283,6 +283,20 @@ function handler(from, to, message) {
     }
     return;
   }
+
+  if (message.indexOf('what prs need a reviewer') > -1) {
+    searchGithub('?assignee=none&labels=S-awaiting-review', 'servo', 'servo', function(error, issues) {
+      if (error) {
+        console.log(error);
+        return;
+      }
+
+      issues.forEach(function(issue) {
+        bot.say(to, issue.title + ': ' + issue.url);
+      });
+    });
+    return;
+  }
 }
 
 bot.addListener("message", handler);


### PR DESCRIPTION
This command lists pull requests with no assignees in the format `title: url`. Currently it lists the PR's in the same channel where the user sent the command. 

Don't know if it would be better to send a PM with the list to the user instead, to avoid spamming the channel.