### PR TITLE
Add delay when printing list of unassigned prs

### DIFF
--- a/server.js
+++ b/server.js
@@ -292,8 +292,10 @@ function handler(from, to, message) {
         return;
       }
 
-      issues.forEach(function(issue) {
-        bot.say(to, issue.title + ': ' + issue.url);
+      issues.forEach(function(issue, index) {
+        setTimeout(function() {
+          bot.say(to, issue.title + ': ' + issue.html_url);
+        }, 650 * (index + 1));
       });
     });
     return;


### PR DESCRIPTION
My approach on fixing the flooding issue when printing the unassigned PR's. I've set it to 650ms to make sure it does not display 5 or more lines in less than 3 secs.

It also fixes the URL, which previously was displaying the API url instead of the correct one: `html_url` (which directs to the issue page). Let me know if this is not intended or if there's a better alternative!