### PR TITLE
Possible solution for issue #35

### DIFF
--- a/server.js
+++ b/server.js
@@ -304,6 +304,49 @@ function handler(from, to, original_message) {
     });
     return;
   }
+  
+  if (message.indexOf('what issue should i poke') > -1) {
+    // github API has the key since, but this unfortunately does the opposite than what is needed
+    // what follows "hopes" that in the returned results there is some issue that was last updated
+    // at most 14 days before the call...
+    var searchPreamble = '?assignee=none&sort=updated&direction=desc&labels=C-assigned'; 
+    
+    searchGithub(searchPreamble + '&labels=E-easy', 'servo', 'servo', function(error, issuesE) {
+      if (error) {
+        console.log(error);
+        return;
+      }
+      
+      searchGithub(searchPreamble + '&labels=E-less easy', 'servo', 'servo', function(error, issuesLE) {
+        if (error) {
+           console.log(error);
+           return;
+        }
+        
+        var today = new Date();
+        var lastUpdated = function(issue) { 
+          var updated_at = new Date(issue.updated_at);
+          var ms = today - updated_at;
+          var days = Math.round(ms / 86400000);
+          return days >= 14;
+        };
+         
+        var issues = issuesE.concat(issuesLE).filter(lastUpdated);
+        var index = choose(issues);
+        var issue = issues[index];
+        var message;
+        if (issue) {
+            console.log(bot.nick + " found issue " + issue.number);
+            
+            message = from + ": try working on issue #" + issue.number + " - " + issue.title + " - " + issue.html_url;
+        } else {
+            message = from + ": couldn't find anything!";
+        }
+        bot.say(to, message);
+      });
+    });
+    return;
+  }
 }
 
 bot.addListener("message", handler);

--- a/server.js
+++ b/server.js
@@ -319,8 +319,8 @@ function handler(from, to, original_message) {
       
       searchGithub(searchPreamble + '&labels=E-less easy', 'servo', 'servo', function(error, issuesLE) {
         if (error) {
-           console.log(error);
-           return;
+          console.log(error);
+          return;
         }
         
         var today = new Date();
@@ -336,11 +336,12 @@ function handler(from, to, original_message) {
         var issue = issues[index];
         var message;
         if (issue) {
-            console.log(bot.nick + " found issue " + issue.number);
+          console.log(bot.nick + " found issue " + issue.number);
             
-            message = from + ": try working on issue #" + issue.number + " - " + issue.title + " - " + issue.html_url;
+          message = from + ": make sure #" + issue.number + " is still being worked on." 
+                    + "\n#" + issue.number + " - " + issue.title + " - " + issue.html_url;
         } else {
-            message = from + ": couldn't find anything!";
+          message = from + ": couldn't find anything!";
         }
         bot.say(to, message);
       });


### PR DESCRIPTION
PR for issue #35.

As mentioned in the comments, github API allows to use a `since:date` key in searches that shows issues updated since that date, but not the other way around. In the solution above I assume that among the results there is one that *has not* been updated since 14 days.

I made few tests and it seems to do the trick.