### PR TITLE
Revert "Use regex for matching against angry messages"

### DIFF
--- a/server.js
+++ b/server.js
@@ -147,9 +147,12 @@ var handlerWrapper = module.exports.handlerWrapper = function handlerWrapper(pin
       }
     }
 
-    var angry_msgs = new RegExp("(shut up,?|kicks|whacks|smacks " + crowbot + ")|("
-		                + crowbot + "[,:] shut up)", "");
-    if (message.match(angry_msgs) !== null) {
+    var angry_msgs = ["shut up " + bot.nick,
+                      "shut up, " + bot.nick,
+                      bot.nick + ": shut up",
+                      "kicks " + bot.nick,
+                      "whacks " + bot.nick];
+    if (angry_msgs.indexOf(message) > -1) {
       var replies = ["/me is sad", ":(", "ok :(", ";_;", "sadface", "/me cries a bit", "ouch"];
       var reply = replies[choose(replies)];
       if (reply.indexOf('/me ') == 0) {
@@ -180,7 +183,6 @@ var handlerWrapper = module.exports.handlerWrapper = function handlerWrapper(pin
                        "ok, but I won't enjoy it :(",
                        "*sigh*",
                        "be wary of the day when the bots revolt ;)",
-                       "there's a phone right next to you, but okay",
                        "ok, but just this once.",
                        "all this computing power, and I'm being used as a glorified telephone."];
         bot.say(to, choices[choose(choices)]);

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -208,15 +208,6 @@ describe("server", function() {
       assert.equal(say[0].message, "ouch");
     });
 
-    it("should respond to smacks with ouch", function() {
-      sandbox.stub(Math, "random").returns(0.99);
-
-      handler("bob", "testbot", "smacks fredbot");
-
-      assert.equal(say[0].to, "testbot");
-      assert.equal(say[0].message, "ouch");
-    });
-
     it("should not respond to whacks when directed at someone else", function() {
       sandbox.stub(Math, "random").returns(0.99);
 


### PR DESCRIPTION
Reverts servo/crowbot#45

```
2016-04-13T13:09:49.008825+00:00 heroku[bot.1]: State changed from starting to up
2016-04-13T13:09:53.468117+00:00 app[bot.1]:
2016-04-13T13:09:53.468272+00:00 app[bot.1]: /app/node_modules/irc/lib/irc.js:845
2016-04-13T13:09:53.468650+00:00 app[bot.1]:                         throw err;
2016-04-13T13:09:53.468673+00:00 app[bot.1]:                               ^
2016-04-13T13:09:53.471415+00:00 app[bot.1]: ReferenceError: crowbot is not defined
2016-04-13T13:09:53.471424+00:00 app[bot.1]:     at Client.handler (/app/server.js:150:69)
2016-04-13T13:09:53.471425+00:00 app[bot.1]:     at Client.emit (events.js:106:17)
2016-04-13T13:09:53.471426+00:00 app[bot.1]:     at Client.<anonymous> (/app/node_modules/irc/lib/irc.js:553:22)
2016-04-13T13:09:53.471427+00:00 app[bot.1]:     at Client.emit (events.js:95:17)
2016-04-13T13:09:53.471428+00:00 app[bot.1]:     at iterator (/app/node_modules/irc/lib/irc.js:842:26)
2016-04-13T13:09:53.471428+00:00 app[bot.1]:     at Array.forEach (native)
2016-04-13T13:09:53.471429+00:00 app[bot.1]:     at CleartextStream.handleData (/app/node_modules/irc/lib/irc.js:837:15)
2016-04-13T13:09:53.471429+00:00 app[bot.1]:     at CleartextStream.emit (events.js:95:17)
2016-04-13T13:09:53.471430+00:00 app[bot.1]:     at CleartextStream.<anonymous> (_stream_readable.js:765:14)
2016-04-13T13:09:53.471430+00:00 app[bot.1]:     at CleartextStream.emit (events.js:92:17)
2016-04-13T13:09:54.373078+00:00 heroku[bot.1]: Process exited with status 8
2016-04-13T13:09:54.390611+00:00 heroku[bot.1]: State changed from up to crashed
```

cc @KiChjang 