### PR TITLE
fixed misleading string values in default config file

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
-	"channels": ["#servo"],
-	"server": "irc.mozilla.org",
-	"botName": "crowbot",
-	"port": "6697",
-	"secure": true,
-    	"autoRejoin": true
+    "channels": ["#servo"],
+    "server": "irc.mozilla.org",
+    "botName": "crowbot",
+    "port": "6697",
+    "secure": true,
+    "autoRejoin": true
 }

--- a/config.json
+++ b/config.json
@@ -3,6 +3,6 @@
 	"server": "irc.mozilla.org",
 	"botName": "crowbot",
 	"port": "6697",
-	"secure": "true",
-    	"autoRejoin": "true"
+	"secure": true,
+    	"autoRejoin": true
 }


### PR DESCRIPTION
The config.json file contained strings instead of booleans for 'secure' and 'autoRejoin' parameters. 

This can lead to unexpected behaviours when changing them without paying attention, since Javascript interpret the "false" string as a true boolean value.